### PR TITLE
Fix(#16)/Landing 페이지 heroSection 버튼 마진 제거

### DIFF
--- a/src/components/sections/HeroSection.jsx
+++ b/src/components/sections/HeroSection.jsx
@@ -85,7 +85,7 @@ export default function HeroSection({ router }) {
                     onPress={() => router.push("/recruit")}
                     radius="full"
                     ref={buttonRef}
-                    className="opacity-0 mt-[41px] w-60 mr-3 h-16 mobile:w-40 mobile:h-14 mobile:text-2xl bg-gradient-to-r from-[#EA4335] to-[#FF6E62] text-white text-3xl relative group"
+                    className="opacity-0 mt-[41px] w-60 h-16 mobile:w-40 mobile:h-14 mobile:text-2xl bg-gradient-to-r from-[#EA4335] to-[#FF6E62] text-white text-3xl relative group"
                 >
                     <span className="font-semibold">지원하기</span>
                 </Button>


### PR DESCRIPTION
## #️⃣연관된 이슈

#16 

## 📝작업 내용

랜딩페이지의 heroSection의 버튼 우측에 마진이 들어가 있어, 살짝 치우쳐 있는 부분을 해결하였습니다.


## 💬리뷰 요구사항(선택)

.